### PR TITLE
Feature: Show actual overlaps

### DIFF
--- a/gdmlview.cc
+++ b/gdmlview.cc
@@ -95,7 +95,8 @@ class DetectorConstruction: public G4VUserDetectorConstruction
         a = std::min(a, AddTransparency(volume->GetLogicalVolume()->GetDaughter(i), alpha));
       volume->GetLogicalVolume()->SetVisAttributes(G4VisAttributes(G4Colour(1,1,1,a)));
       return a * alpha;
-    }
+    };
+
     void DrawOverlap() {
       for (std::vector< std::tuple<G4VPhysicalVolume*, G4VSolid* > >::const_iterator
             it  = fOverlaps.begin(); it != fOverlaps.end(); it++) {

--- a/tests/overlap.gdml
+++ b/tests/overlap.gdml
@@ -1,0 +1,56 @@
+<gdml xmlns:gdml="http://cern.ch/2001/Schemas/GDML"
+      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:noNamespaceSchemaLocation="schema/gdml.xsd">
+
+<define>
+</define>
+
+<materials>
+</materials>
+
+<solids>
+  <box name="world_solid" x="40.0" y="40.0" z="40.0" lunit="mm"/>
+  <box name="box1_solid" x="20.0" y="20.0" z="20.0" lunit="mm"/>
+  <box name="box2_solid" x="20.0" y="20.0" z="20.0" lunit="mm"/>
+  <box name="box3_solid" x="20.0" y="20.0" z="20.0" lunit="mm"/>
+</solids>
+
+<structure>
+  <volume name="box1_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="box1_solid"/>
+  </volume>
+  <volume name="box2_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="box2_solid"/>
+  </volume>
+  <volume name="box3_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="box3_solid"/>
+  </volume>
+  <volume name="world_logical">
+    <materialref ref="G4_Galactic"/>
+    <solidref ref="world_solid"/>
+    <physvol name="box1_physical">
+      <volumeref ref="box1_logical"/>
+      <position x="-8.5" lunit="mm"/>
+      <rotation y="30" z="30" aunit="deg"/>
+    </physvol>
+    <physvol name="box2_physical">
+      <volumeref ref="box2_logical"/>
+      <position x="+8.5" lunit="mm"/>
+      <rotation y="-30" z="30" aunit="deg"/>
+    </physvol>
+    <physvol name="box3_physical">
+      <volumeref ref="box3_logical"/>
+      <position x="15.0" lunit="mm"/>
+      <rotation y="60" z="-30" aunit="deg"/>
+    </physvol>
+  </volume>
+</structure>
+
+<setup name="Default" version="1.0">
+  <world ref="world_logical"/>
+</setup>
+
+</gdml>


### PR DESCRIPTION
This PR uses intersection solids between overlapping sibling volumes and subtraction solids between daughter and mother volumes to visualize overlap with non-transparent placements.

![image](https://user-images.githubusercontent.com/4656391/82383945-74457380-99f4-11ea-8629-26b440aafd71.png)
